### PR TITLE
Add Subscriptions Migrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,17 @@
 		If this flag is added, the migrator will send out 'New Account created' email notifications to users, for every new user imported; and 'New
 	 order' notification for each order to the site admin email. Beware of potential spamming before adding this flag!
 ```
+
+```
+  wp migrator skio_subscriptions [--subscriptions_export_file] [--orders_export_file ]
+
+  The json files can downloaded from the Skio dashboard at https://dashboard.skio.com/subscriptions/export 
+
+  OPTIONS
+
+  [--subscriptions_export_file]
+    The subscriptions json file exported from Skio dashboard
+
+  [--orders_export_file]
+    The orders json file exported from Skio dashboard
+```

--- a/config.example.php
+++ b/config.example.php
@@ -1,4 +1,3 @@
 <?php
 const ACCESS_TOKEN = 'shpat_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx';
 const SHOPIFY_DOMAIN = 'your-store.myshopify.com';
-const SKIO_TOKEN = '';//If site uses SKIO for subscriptions

--- a/config.example.php
+++ b/config.example.php
@@ -1,3 +1,4 @@
 <?php
 const ACCESS_TOKEN = 'shpat_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx';
 const SHOPIFY_DOMAIN = 'your-store.myshopify.com';
+const SKIO_TOKEN = '';//If site uses SKIO for subscriptions

--- a/includes/subscriptions.php
+++ b/includes/subscriptions.php
@@ -185,6 +185,12 @@ class Migrator_CLI_Subscriptions {
 	}
 
 	private function add_line_items( $subscription, $latest_order ) {
+
+		// Prevents duplication on updates.
+		foreach ( $latest_order->get_items( array( 'line_item', 'tax', 'shipping', 'coupon' ) ) as $subscription_item ) {
+			$subscription->remove_item( $subscription_item );
+		}
+
 		foreach ( $latest_order->get_items( array( 'line_item', 'tax', 'shipping', 'coupon' ) ) as $item ) {
 			$this->clone_item_to_subscription( $item, $subscription );
 		}

--- a/includes/subscriptions.php
+++ b/includes/subscriptions.php
@@ -1,0 +1,252 @@
+<?php
+
+class Migrator_CLI_Subscriptions {
+	public function import($assoc_args ) {
+
+		try {
+			Migrator_CLI_Utils::health_check();
+
+			if (!isset($assoc_args['subscriptions_export_file']) || !isset($assoc_args['orders_export_file'])) {
+				WP_CLI::line( WP_CLI::colorize('%RExport Files not provided. Go to Skio dashboard > Export and export both subscriptions and orders. Then pass the file path to --subscriptions_export_file and --orders_export_file args') );
+				return;
+			}
+
+			Migrator_CLI_Utils::disable_sequential_orders();
+
+			$skio_orders = $this->get_data_from_file( $assoc_args['orders_export_file'] );
+
+			WP_CLI::line('Adding Subscription ids to orders');
+			$this->add_subscription_id_to_orders( $skio_orders );
+
+			$skio_subscriptions = $this->get_data_from_file( $assoc_args['subscriptions_export_file'] );
+
+			WP_CLI::line('Creating Subscriptions');
+			$this->create_or_update_subscriptions( $skio_subscriptions );
+
+			Migrator_CLI_Utils::enable_sequential_orders();
+		} catch ( \Exception $e ) {
+			WP_CLI::line( WP_CLI::colorize(' %rError: ' . $e->getMessage() ) );
+		}
+
+		WP_CLI::line( WP_CLI::colorize('%GDone%n') );
+	}
+
+	// Clones the line item and adds it to the subscription.
+	private function clone_item_to_subscription( $item, $subscription ) {
+		$new_item = clone $item;
+		$new_item->set_id( 0 );
+		$new_item->set_order_id( $subscription->get_id() );
+		$new_item->save();
+
+		$subscription->add_item( $new_item );
+	}
+
+	private function get_data_from_file( $file )
+	{
+		return json_decode(file_get_contents( $file ), true);
+	}
+
+	private function add_subscription_id_to_orders( $skio_orders ) {
+		foreach ($skio_orders as $shopify_order) {
+			WP_CLI::line('Processing order: ' . $shopify_order['orderPlatformNumber']);
+
+			$args = array(
+				'meta_key' => '_order_number',
+				'meta_value' => $shopify_order['orderPlatformNumber'],
+				'meta_compare' => '=',
+				'numberposts' => 1,
+			);
+
+			$skio_orders = wc_get_orders($args);
+
+			if (!$skio_orders) {
+				WP_CLI::line('Woo Order not found for Shopify Order: ' . $shopify_order['orderPlatformNumber']);
+				continue;
+			}
+
+			/** @var WC_Order $shopify_order */
+			$order = reset($skio_orders);
+			$order->add_meta_data('_skio_subscription_id', $shopify_order['subscriptionId']);
+			$order->save_meta_data();
+		}
+	}
+
+	private function create_or_update_subscriptions($skio_subscriptions ) {
+		foreach ($skio_subscriptions as $skio_subscription) {
+			WP_CLI::line('Processing subscription: ' . $skio_subscription['subscriptionId']);
+
+			// Get all the orders for that subscription.
+			$args = array(
+				'meta_key' => '_skio_subscription_id',
+				'meta_value' => $skio_subscription['subscriptionId'],
+				'meta_compare' => '=',
+				'numberposts' => -1,
+			);
+
+			$existing_orders = wc_get_orders($args);
+
+			if (!$existing_orders) {
+				WP_CLI::line('Woo Order not found for Skio Subscription: ' . $skio_subscription['subscriptionId']);
+				continue;
+			}
+
+			// Used as the order that originated the subscription.
+			$oldest_order = reset($existing_orders);
+			// Most up to date order to make sure the subscription is correct.
+			$latest_order = end($existing_orders);
+
+			$subscription = $this->get_or_create_subscription( $skio_subscription, $oldest_order );
+
+			if ( is_wp_error( $subscription) ) {
+				WP_CLI::line('Error when creating the subscription: ' . $subscription->get_error_message());
+				continue;
+			}
+
+			$this->add_line_items( $subscription, $latest_order );
+			$this->update_billing_address( $subscription, $latest_order );
+			$this->update_shipping_address( $subscription, $latest_order );
+
+			$subscription->set_requires_manual_renewal(true);
+			$subscription->set_payment_method($latest_order->get_payment_method());
+			$subscription->set_payment_method_title($latest_order->get_payment_method_title());
+			$subscription->set_shipping_total($latest_order->get_shipping_total());
+
+
+			$subscription->add_meta_data('_payment_method_id', $latest_order->get_meta('_payment_method_id'));
+			$subscription->add_meta_data('_payment_tokens', $latest_order->get_meta('_payment_tokens'));
+			$subscription->add_meta_data('_skio_subscription_id', $skio_subscription['subscriptionId']);
+
+			$this->attatch_orders( $subscription, $existing_orders, $oldest_order );
+			$this->set_subscription_status( $subscription, $skio_subscription );
+
+			$subscription->save();
+			$subscription->calculate_totals();
+		}
+	}
+
+	private function get_or_create_subscription( $skio_subscription, $oldest_order ) {
+		$args = array(
+			'type' => 'shop_subscription',
+			'meta_key' => '_skio_subscription_id',
+			'meta_value' => $skio_subscription['subscriptionId'],
+			'meta_compare' => '=',
+			'numberposts' => 1,
+			'status' => 'any',
+		);
+
+		$existing_subscriptions = wcs_get_orders_with_meta_query($args);
+
+		if ($existing_subscriptions) {
+			/** @var WC_Subscription $subscription */
+			$subscription = end($existing_subscriptions);
+
+			$subscription->update_dates(array(
+				'cancelled' => 0,
+				'end' => 0,
+				'next_payment' => 0,
+				'start' => 0,
+				'date_created' => 0,
+				'date_modified' => 0,
+				'date_paid' => 0,
+				'date_completed' => 0,
+				'last_order_date_created' => 0,
+				'trial_end' => 0,
+				'last_order_date_paid' => 0,
+				'last_order_date_completed' => 0,
+				'payment_retry' => 0,
+			));
+
+			$subscription->save();
+
+			WP_CLI::line('Found existing subscription updating it instead');
+		} else {
+			WP_CLI::line('Creating new subscription');
+
+			$create_date = date_create($skio_subscription['createdAt']);
+			$create_date = date_format($create_date, 'Y-m-d H:i:s');
+
+			$subscription = wcs_create_subscription(
+				array(
+					'status' => '',
+					'order_id' => $oldest_order->get_id(),
+					'customer_id' => $oldest_order->get_customer_id(),
+					'date_created' => $create_date,
+					'billing_interval' => $skio_subscription['billingPolicyIntervalCount'],
+					'billing_period' => mb_strtolower($skio_subscription['billingPolicyInterval']),
+				)
+			);
+		}
+
+		return $subscription;
+	}
+
+	private function add_line_items( $subscription, $latest_order ) {
+		foreach ($latest_order->get_items(array('line_item', 'tax', 'shipping', 'coupon')) as $item) {
+			$this->clone_item_to_subscription($item, $subscription);
+		}
+	}
+
+	private function update_billing_address( $subscription, $latest_order ) {
+		$subscription->set_billing_first_name($latest_order->get_billing_first_name());
+		$subscription->set_billing_last_name($latest_order->get_billing_last_name());
+		$subscription->set_billing_company($latest_order->get_billing_company());
+		$subscription->set_billing_address_1($latest_order->get_billing_address_1());
+		$subscription->set_billing_address_2($latest_order->get_billing_address_2());
+		$subscription->set_billing_city($latest_order->get_billing_city());
+		$subscription->set_billing_state($latest_order->get_billing_state());
+		$subscription->set_billing_postcode($latest_order->get_billing_postcode());
+		$subscription->set_billing_country($latest_order->get_billing_country());
+		$subscription->set_billing_phone($latest_order->get_billing_phone());
+	}
+
+	private function update_shipping_address( $subscription, $latest_order ) {
+		$subscription->set_shipping_first_name($latest_order->get_shipping_first_name());
+		$subscription->set_shipping_last_name($latest_order->get_shipping_last_name());
+		$subscription->set_shipping_company($latest_order->get_shipping_company());
+		$subscription->set_shipping_address_1($latest_order->get_shipping_address_1());
+		$subscription->set_shipping_address_2($latest_order->get_shipping_address_2());
+		$subscription->set_shipping_city($latest_order->get_shipping_city());
+		$subscription->set_shipping_state($latest_order->get_shipping_state());
+		$subscription->set_shipping_postcode($latest_order->get_shipping_postcode());
+		$subscription->set_shipping_country($latest_order->get_shipping_country());
+		$subscription->set_shipping_phone($latest_order->get_shipping_phone());
+
+	}
+
+	private function attatch_orders( $subscription, $existing_orders, $oldest_order ) {
+		foreach ($existing_orders as $order) {
+			// Prevents adding the oldest order twice.
+			if ( $order->get_id() == $oldest_order->get_id() ) {
+				continue;
+			}
+
+			WCS_Related_Order_Store::instance()->add_relation($order, $subscription, 'renewal');
+		}
+	}
+
+	private function set_subscription_status( $subscription, $skio_subscription ) {
+
+		if (!in_array($skio_subscription['status'], array('ACTIVE', 'CANCELLED'), true)) {
+			WP_CLI::line('Unknown subscription status: ' . $skio_subscription['status']);
+		}
+
+		$subscription->set_status( mb_strtolower( $skio_subscription['status'] ) );
+
+		if ('ACTIVE' === $skio_subscription['status'] && isset($skio_subscription['nextBillingDate'])) {
+			$next_payment = date_create($skio_subscription['nextBillingDate']);
+			$next_payment = date_format($next_payment, 'Y-m-d H:i:s');
+			$subscription->update_dates(array(
+				'next_payment' => $next_payment,
+			));
+		}
+
+		if ( 'CANCELLED' === $skio_subscription['status'] && isset( $skio_subscription['cancelledAt'] ) ) {
+			$cancelled_date = new DateTime($skio_subscription['cancelledAt']);
+			$cancelled_date = date_format($cancelled_date, 'Y-m-d H:i:s');
+			$subscription->update_dates(array(
+				'cancelled' => $cancelled_date,
+				'end' => $cancelled_date
+			));
+		}
+	}
+}

--- a/includes/subscriptions.php
+++ b/includes/subscriptions.php
@@ -85,6 +85,8 @@ class Migrator_CLI_Subscriptions {
 				'meta_value' => $skio_subscription['subscriptionId'],
 				'meta_compare' => '=',
 				'numberposts' => -1,
+				'orderby' => 'date_created',
+				'order' => 'ASC',
 			);
 
 			$existing_orders = wc_get_orders( $args );

--- a/includes/subscriptions.php
+++ b/includes/subscriptions.php
@@ -183,6 +183,8 @@ class Migrator_CLI_Subscriptions {
 			);
 		}
 
+		WP_CLI::line( 'Woo Subscription id: ' . $subscription->get_id() );
+
 		return $subscription;
 	}
 

--- a/includes/subscriptions.php
+++ b/includes/subscriptions.php
@@ -11,14 +11,13 @@ class Migrator_CLI_Subscriptions {
 				return;
 			}
 
-			Migrator_CLI_Utils::disable_sequential_orders();
-
 			$skio_orders = $this->get_data_from_file( $assoc_args['orders_export_file'] );
+			$skio_subscriptions = $this->get_data_from_file( $assoc_args['subscriptions_export_file'] );
+
+			Migrator_CLI_Utils::disable_sequential_orders();
 
 			WP_CLI::line( 'Adding Subscription ids to orders' );
 			$this->add_subscription_id_to_orders( $skio_orders );
-
-			$skio_subscriptions = $this->get_data_from_file( $assoc_args['subscriptions_export_file'] );
 
 			WP_CLI::line( 'Creating Subscriptions' );
 			$this->create_or_update_subscriptions( $skio_subscriptions );
@@ -43,6 +42,11 @@ class Migrator_CLI_Subscriptions {
 
 	private function get_data_from_file( $file )
 	{
+		if ( ! is_file( $file ) ) {
+			WP_CLI::line( WP_CLI::colorize( '%RFile not found: ' . $file ) );
+			die();
+		}
+
 		return json_decode(file_get_contents( $file ), true);
 	}
 

--- a/includes/subscriptions.php
+++ b/includes/subscriptions.php
@@ -187,8 +187,8 @@ class Migrator_CLI_Subscriptions {
 	private function add_line_items( $subscription, $latest_order ) {
 
 		// Prevents duplication on updates.
-		foreach ( $latest_order->get_items( array( 'line_item', 'tax', 'shipping', 'coupon' ) ) as $subscription_item ) {
-			$subscription->remove_item( $subscription_item );
+		foreach ( $subscription->get_items( array( 'line_item', 'tax', 'shipping', 'coupon' ) ) as $subscription_item ) {
+			$subscription->remove_item( $subscription_item->get_id() );
 		}
 
 		foreach ( $latest_order->get_items( array( 'line_item', 'tax', 'shipping', 'coupon' ) ) as $item ) {

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -1,0 +1,31 @@
+<?php
+
+class Migrator_CLI_Utils {
+	public static function health_check() {
+		if ( ! function_exists( 'wc_get_orders' ) ) {
+			WP_CLI::error( 'WooCommerce is not active.' );
+		}
+
+		if ( ! ACCESS_TOKEN ) {
+			WP_CLI::error( 'Missing Shopify access token.' );
+		}
+
+		if ( ! SHOPIFY_DOMAIN ) {
+			WP_CLI::error( 'Missing Shopify domain.' );
+		}
+	}
+
+	public static function disable_sequential_orders() {
+		if ( is_plugin_active( 'woocommerce-sequential-order-numbers/woocommerce-sequential-order-numbers.php' ) ) {
+			WP_CLI::line( WP_CLI::colorize( '%BInfo:%n ' ) . 'We need to disable WooCommerce Sequential Order Numbers plugin while migration to ensure the order number is set correctly. The plugin will be enabled again after migration finished.' );
+			WP_CLI::runcommand( 'plugin deactivate woocommerce-sequential-order-numbers' );
+		}
+	}
+
+	public static function enable_sequential_orders() {
+		if ( is_plugin_active( 'woocommerce-sequential-order-numbers/woocommerce-sequential-order-numbers.php' ) ) {
+			WP_CLI::line( WP_CLI::colorize( '%BInfo:%n ' ) . 'Enabling WooCommerce Sequential Order Numbers plugin.' );
+			WP_CLI::runcommand( 'plugin activate woocommerce-sequential-order-numbers' );
+		}
+	}
+}

--- a/migrator.php
+++ b/migrator.php
@@ -1687,13 +1687,15 @@ class Migrator_CLI extends WP_CLI_Command {
 
 
 	public function subscriptions() {
-		$order        = new WC_Order( 33598 );
+		$customer_id  = 1;
+		$order_id     = 33598;
+		$order        = new WC_Order( $order_id );
 		$now          = gmdate( 'Y-m-d H:i:s' );
 		$subscription = wcs_create_subscription(
 			array(
 				'status'             => '',
 				'order_id'           => $order->get_id(),
-				'customer_id'        => 1,
+				'customer_id'        => $customer_id,
 				'date_created'       => $now,
 				'billing_interval'	 => 4,
 				'billing_period'	 => 'week'
@@ -1733,10 +1735,14 @@ class Migrator_CLI extends WP_CLI_Command {
 		$subscription->set_shipping_country( $order->get_shipping_country() );
 		$subscription->set_shipping_phone( $order->get_shipping_phone() );
 
+		$subscription->set_payment_method( $order->get_payment_method() );
+		$subscription->set_payment_method_title( $order->get_payment_method_title() );
+		$subscription->set_status( 'active' );
 
+		$subscription->add_meta_data('_payment_method_id', $order->get_meta( '_payment_method_id' ) );
+		$subscription->add_meta_data('_payment_tokens', $order->get_meta( '_payment_tokens' ) );
 
 		// nextBillingDate?
-
 
 		$subscription->save();
 		$subscription->calculate_totals();

--- a/migrator.php
+++ b/migrator.php
@@ -159,7 +159,7 @@ class Migrator_CLI extends WP_CLI_Command {
 
 	/**
 	 * Migrate products from Shopify to WooCommerce.
-   *
+	*
 	 * ## OPTIONS
 	 *
 	 * [--before]
@@ -858,7 +858,7 @@ class Migrator_CLI extends WP_CLI_Command {
 			}
 
 			$attributes = array_map(
-				function( $taxonomy, $value ) {
+				function ( $taxonomy, $value ) {
 					$attribute = new WC_Product_Attribute();
 					$attribute->set_name( $taxonomy );
 					$attribute->set_id( wc_attribute_taxonomy_id_by_name( $taxonomy ) );
@@ -1611,7 +1611,7 @@ class Migrator_CLI extends WP_CLI_Command {
 			$refund->update_meta_data( '_refund_completed_date', $shopify_refund->processed_at );
 
 			// Update refund transaction ID
-			if ( count ( $shopify_refund->transactions ) > 0 && property_exists( $shopify_refund->transactions[0], 'receipt') && property_exists( $shopify_refund->transactions[0]->receipt, 'refund_transaction_id' ) ) {
+			if ( count( $shopify_refund->transactions ) > 0 && property_exists( $shopify_refund->transactions[0], 'receipt' ) && property_exists( $shopify_refund->transactions[0]->receipt, 'refund_transaction_id' ) ) {
 				$refund->update_meta_data( '_transaction_id', $shopify_refund->transactions[0]->receipt->refund_transaction_id );
 			}
 
@@ -1686,66 +1686,164 @@ class Migrator_CLI extends WP_CLI_Command {
 	}
 
 
-	public function subscriptions() {
-		$customer_id  = 1;
-		$order_id     = 33598;
-		$order        = new WC_Order( $order_id );
-		$now          = gmdate( 'Y-m-d H:i:s' );
-		$subscription = wcs_create_subscription(
-			array(
-				'status'             => '',
-				'order_id'           => $order->get_id(),
-				'customer_id'        => $customer_id,
-				'date_created'       => $now,
-				'billing_interval'	 => 4,
-				'billing_period'	 => 'week'
-			)
-		);
+	public function subscriptions( $args, $assoc_args ) {
+		$this->health_check();
+		$this->assoc_args = $assoc_args;
 
-		$subscription->set_requires_manual_renewal( true );
+		$offset = isset( $assoc_args['offset'] ) ? $assoc_args['offset'] : null;
+		$limit  = isset( $assoc_args['limit'] ) ? $assoc_args['limit'] : 1000;
 
-		// Line Items.
-		foreach ( $order->get_items( array( 'line_item', 'tax', 'shipping', 'coupon' ) ) as $item ) {
-			$this->clone_item_to_subscription( $item, $subscription );
+		if ( is_plugin_active( 'woocommerce-sequential-order-numbers/woocommerce-sequential-order-numbers.php' ) ) {
+			WP_CLI::line( WP_CLI::colorize( '%BInfo:%n ' ) . 'We need to disable WooCommerce Sequential Order Numbers plugin while migration to ensure the order number is set correctly. The plugin will be enabled again after migration finished.' );
+			WP_CLI::runcommand( 'plugin deactivate woocommerce-sequential-order-numbers' );
 		}
 
-		$subscription->set_shipping_total( $order->get_shipping_total() );
+		$endpoint = 'https://graphql.skio.com/v1/graphql';
+		$qry      = "{\"query\":\"query {Subscriptions(limit: $limit, order_by: { createdAt: asc }, where: { status: { _eq: ACTIVE } }) { billingPolicyId cancelledAt createdAt currencyCode customAttributes cyclesCompleted deliveryPolicyId deliveryPrice deliveryPriceOverride id lastBillingAttemptAt metadata migrationIndex nextBillingDate originOrderId platformId prepaidDeliveryPolicyId prepaidProductPricesPerDelivery shippingAddressId siteId status statusContext storefrontUserId updatedAt BillingPolicy {  createdAt  id  interval  intervalCount  maxCycles  minCycles  updatedAt } originOrder {  cancelledAt  clientIp  createdAt  deletedAt  deliveredAt  id  note  platformId  platformNumber  processedAt  storefrontUserId  updatedAt } SubscriptionLines {  createdAt  customAttributes  groupId  id  ordersRemaining  platformId  prepaidSubscriptionId  priceWithoutDiscount  productVariantId  quantity  removedAt  sellingPlanId  subscriptionId  taxable  titleOverride  updatedAt } StorefrontUser {  createdAt  email  firstName  id  lastName  phoneNumber  platformId  redactedAt  shopifyTags  siteId  updatedAt } Site {  ianaTimezone  id } ShippingAddress {  address1  address2  city  company  country  createdAt  doorCode  firstName  id  lastName  phoneNumber  platformId  province  storefrontUserId  updatedAt  zip } PrepaidSubscriptionLines {  createdAt  customAttributes  groupId  id  ordersRemaining  platformId  prepaidSubscriptionId  priceWithoutDiscount  productVariantId  quantity  removedAt  sellingPlanId  subscriptionId  taxable  titleOverride  updatedAt } PrepaidGiftRecipient {  createdAt  email  firstName  id  lastName  phoneNumber  platformId  redactedAt  shopifyTags  siteId  updatedAt } PrepaidDeliveryPolicy {  createdAt  id  interval  intervalCount  maxCycles  minCycles  updatedAt } PaymentMethod {  billingAddressId  brand  createdAt  expiryMonth  expiryYear  id  lastDigits  platformId  revokedAt  storefrontUserId  updatedAt } NotificationLogs {  body  createdAt  email  id  notificationId  phoneNumber  subject  subscriptionId  updatedAt } FulfillmentOrders {  cancelledAt  clientIp  createdAt  deletedAt  deliveredAt  id  note  platformId  platformNumber  processedAt  storefrontUserId  updatedAt } Discounts {  cancelFlowSessionId  createdAt  fixedValue  groupId  groupPlanId  id  maxTimesUsed  orderLineItemId  percentage  platformId  redeemCode  shippingLineId  subscriptionId  subscriptionLineId  timesUsed  type  updatedAt } DeliveryPolicy {  createdAt  id  interval  intervalCount  maxCycles  minCycles  updatedAt } CancelFlowV2Sessions {  action  actions  cancelFlowId  conditions  created_at  id  isMultipleActions  isOtherReason  reason  rebuttal  rebuttalOptions  shownActions  shownReasons  shownRebuttals  status  subscriptionId  updated_at } CancelFlowSessions {  cancelFlowId  createdAt  id  status  subscriptionId  updatedAt } AuditLogs {  createdAt  eventData  eventType  id  storefrontUserId  subscriptionId  updatedAt } }}\"}";
 
-		// Update order billing address.
-		$subscription->set_billing_first_name( $order->get_billing_first_name() );
-		$subscription->set_billing_last_name( $order->get_billing_last_name() );
-		$subscription->set_billing_company( $order->get_billing_company() );
-		$subscription->set_billing_address_1( $order->get_billing_address_1() );
-		$subscription->set_billing_address_2( $order->get_billing_address_2() );
-		$subscription->set_billing_city( $order->get_billing_city() );
-		$subscription->set_billing_state( $order->get_billing_state() );
-		$subscription->set_billing_postcode( $order->get_billing_postcode() );
-		$subscription->set_billing_country( $order->get_billing_country() );
-		$subscription->set_billing_phone( $order->get_billing_phone() );
+		$headers   = array();
+		$headers[] = 'Content-Type: application/json';
+		$headers[] = 'Authorization: API ' . SKIO_TOKEN;
 
-		// Update order shipping address.
-		$subscription->set_shipping_first_name( $order->get_shipping_first_name() );
-		$subscription->set_shipping_last_name( $order->get_shipping_last_name() );
-		$subscription->set_shipping_company( $order->get_shipping_company() );
-		$subscription->set_shipping_address_1( $order->get_shipping_address_1() );
-		$subscription->set_shipping_address_2( $order->get_shipping_address_2() );
-		$subscription->set_shipping_city( $order->get_shipping_city() );
-		$subscription->set_shipping_state( $order->get_shipping_state() );
-		$subscription->set_shipping_postcode( $order->get_shipping_postcode() );
-		$subscription->set_shipping_country( $order->get_shipping_country() );
-		$subscription->set_shipping_phone( $order->get_shipping_phone() );
+		$ch = curl_init();
 
-		$subscription->set_payment_method( $order->get_payment_method() );
-		$subscription->set_payment_method_title( $order->get_payment_method_title() );
-		$subscription->set_status( 'active' );
+		curl_setopt( $ch, CURLOPT_URL, $endpoint );
+		curl_setopt( $ch, CURLOPT_RETURNTRANSFER, 1 );
+		curl_setopt( $ch, CURLOPT_POSTFIELDS, $qry );
+		curl_setopt( $ch, CURLOPT_POST, 1 );
+		curl_setopt( $ch, CURLOPT_HTTPHEADER, $headers );
 
-		$subscription->add_meta_data('_payment_method_id', $order->get_meta( '_payment_method_id' ) );
-		$subscription->add_meta_data('_payment_tokens', $order->get_meta( '_payment_tokens' ) );
+		$result = curl_exec( $ch );
 
-		// nextBillingDate?
+		if ( curl_errno( $ch ) ) {
+			WP_CLI::line( 'Could not retrieve Skio Subscriptions curl error:' . curl_error( $ch ) );
+			return;
+		}
 
-		$subscription->save();
-		$subscription->calculate_totals();
+		$subscriptions = json_decode( $result, true );
+
+		foreach ( $subscriptions['data']['Subscriptions'] as $skio_subscription ) {
+
+			if ( empty( $skio_subscription['originOrder'] ) || ! $skio_subscription['originOrder']['platformNumber'] ) {
+				WP_CLI::line( 'Subscription without origin order. Subscription id: '. $skio_subscription['id'] );
+				continue;
+			}
+
+			$args = array(
+				'meta_key'     => '_order_number',
+				'meta_value'   => $skio_subscription['originOrder']['platformNumber'],
+				'meta_compare' => '=',
+				'numberposts'  => 1,
+			);
+
+			$orders = wc_get_orders( $args );
+
+			if ( ! $orders ) {
+				WP_CLI::line( 'Woo Order not found for Shopify Order: ' . $skio_subscription['originOrder']['platformNumber'] );
+				continue;
+			}
+
+			$order        = reset( $orders );
+			$create_date  = date_create( $skio_subscription['BillingPolicy']['createdAt'] );
+			$create_date  = date_format( $create_date, 'Y-m-d H:i:s' );
+			$subscription = wcs_create_subscription(
+				array(
+					'status'           => '',
+					'order_id'         => $order->get_id(),
+					'customer_id'      => $order->get_customer_id(),
+					'date_created'     => $create_date,
+					'billing_interval' => $skio_subscription['BillingPolicy']['intervalCount'],
+					'billing_period'   => mb_strtolower( $skio_subscription['BillingPolicy']['interval'] ),
+				)
+			);
+
+			if ( is_wp_error( $subscription ) ) {
+				WP_CLI::line( 'Error when creating the subscription: ' . $subscription->get_error_message() );
+				continue;
+			}
+
+			$subscription->set_requires_manual_renewal( true );
+
+			// Line Items.
+			foreach ( $order->get_items( array( 'line_item', 'tax', 'shipping', 'coupon' ) ) as $item ) {
+				$this->clone_item_to_subscription( $item, $subscription );
+			}
+
+			$subscription->set_shipping_total( $order->get_shipping_total() );
+
+			// Update order billing address.
+			$subscription->set_billing_first_name( $order->get_billing_first_name() );
+			$subscription->set_billing_last_name( $order->get_billing_last_name() );
+			$subscription->set_billing_company( $order->get_billing_company() );
+			$subscription->set_billing_address_1( $order->get_billing_address_1() );
+			$subscription->set_billing_address_2( $order->get_billing_address_2() );
+			$subscription->set_billing_city( $order->get_billing_city() );
+			$subscription->set_billing_state( $order->get_billing_state() );
+			$subscription->set_billing_postcode( $order->get_billing_postcode() );
+			$subscription->set_billing_country( $order->get_billing_country() );
+			$subscription->set_billing_phone( $order->get_billing_phone() );
+
+			// Update order shipping address.
+			$subscription->set_shipping_first_name( $order->get_shipping_first_name() );
+			$subscription->set_shipping_last_name( $order->get_shipping_last_name() );
+			$subscription->set_shipping_company( $order->get_shipping_company() );
+			$subscription->set_shipping_address_1( $order->get_shipping_address_1() );
+			$subscription->set_shipping_address_2( $order->get_shipping_address_2() );
+			$subscription->set_shipping_city( $order->get_shipping_city() );
+			$subscription->set_shipping_state( $order->get_shipping_state() );
+			$subscription->set_shipping_postcode( $order->get_shipping_postcode() );
+			$subscription->set_shipping_country( $order->get_shipping_country() );
+			$subscription->set_shipping_phone( $order->get_shipping_phone() );
+
+			$subscription->set_payment_method( $order->get_payment_method() );
+			$subscription->set_payment_method_title( $order->get_payment_method_title() );
+
+			if ( ! in_array( $skio_subscription['status'], array( 'ACTIVE', 'CANCELLED' ), true ) ) {
+				WP_CLI::line( 'Unknown subscription status: ' . $skio_subscription['status'] );
+			}
+
+			$subscription->set_status( $skio_subscription['status'] );
+
+			$subscription->add_meta_data( '_payment_method_id', $order->get_meta( '_payment_method_id' ) );
+			$subscription->add_meta_data( '_payment_tokens', $order->get_meta( '_payment_tokens' ) );
+
+			foreach ( $skio_subscription['NotificationLogs'] as $skio_note ) {
+
+				if ( ! $skio_note['body'] ) {
+					continue;
+				}
+
+				$to = $skio_note['email'];
+
+				if ( $to ) {
+					$to = $skio_note['phoneNumber'];
+				}
+
+				$note = esc_html(
+					sprintf(
+						// translators: %1$s Email or phone number, %2$s Message, %3$s Date.
+						__( 'Notification sent to: %1$s. Message: "%2$s". Date: %3$s' ),
+						array(
+							$to,
+							$skio_note['body'],
+							$skio_note['createdAt'],
+						)
+					)
+				);
+
+				$subscription->add_order_note( $note );
+			}
+
+			// nextBillingDate?
+
+			$subscription->save();
+			$subscription->calculate_totals();
+		}
+
+		if ( is_plugin_active( 'woocommerce-sequential-order-numbers/woocommerce-sequential-order-numbers.php' ) ) {
+			WP_CLI::line( WP_CLI::colorize( '%BInfo:%n ' ) . 'Enabling WooCommerce Sequential Order Numbers plugin.' );
+			WP_CLI::runcommand( 'plugin activate woocommerce-sequential-order-numbers' );
+		}
 	}
 
 	// Clones the line item and adds it to the subscription.

--- a/migrator.php
+++ b/migrator.php
@@ -1668,7 +1668,24 @@ class Migrator_CLI extends WP_CLI_Command {
 		return $woo_status;
 	}
 
-	public function subscriptions( $args, $assoc_args ) {
+	/**
+	 * Migrate subscriptions from Skio to WooCommerce.
+	 * This funciton will import from json files not from the api.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--subscriptions_export_file]
+	 * : The subscriptions json file exported from Skio dashboard
+	 *
+	 *  [--orders_export_file]
+	 * : The orders json file exported from Skio dashboard
+	 *
+	 * Example:
+	 * wp migrator skio_subscriptions --subscriptions_export_file=subscriptions.json --orders_export_file=orders.json
+	 *
+	 * @when after_wp_load
+	 */
+	public function skio_subscriptions( $args, $assoc_args ) {
 		$this->assoc_args = $assoc_args;
 
 		$subscriptions = new Migrator_CLI_Subscriptions();


### PR DESCRIPTION
This PR adds a way to migrate Subscriptions


### Test instructions
- Checkout to this PR's branch
- Create two orders with the same product
- Update the orders creation date via the /wp-admin order edit page to `2023-01-07` and `2023-01-08`
- Add a `_order_number` meta and set it to `11664` in the oldest order
- Add a `_order_number` meta and set it to `11665` in the newest order
- Download these files
[orders.json](https://github.com/woocommerce/migrator-cli/files/13044179/orders.json)
[subscriptions.json](https://github.com/woocommerce/migrator-cli/files/13044180/subscriptions.json)
- Run `wp migrator skio_subscriptions --subscriptions_export_file=<file_path>  --orders_export_file=<file_path>`
- Make sure the subscription was created and uses the shipping and billing data from the newest order
- Change the shipping and billing address in the newest order
- Run `wp migrator skio_subscriptions --subscriptions_export_file=<file_path>  --orders_export_file=<file_path>` again
- Make sure the subscription got updated
- Change the status from `ACTIVE` to `CANCELLED` in the subscription.json file
- Run `wp migrator skio_subscriptions --subscriptions_export_file=<file_path>  --orders_export_file=<file_path>` again
- Make sure the subscription is now cancelled
- Run any other tests you think need to run