### PR TITLE
Mask email and phone in test mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 3. Grab the Shopify Access token by [creating a custom app](https://help.shopify.com/en/manual/apps/app-types/custom-apps). Make sure the required scopes for products and orders migration are selected.
 4. Update domain and access token in the config.php file.
 5. Activate the plugin.
+6. Important note for Order migration - To prevent accidental sending of notifications, there is a `--mode` flag that is set to test by default. This masks the email and phone. Please add `--mode=live` flag whenever you wish to do a final migration with unmasked email and phone. 
 
 ## Commands
 
@@ -62,7 +63,7 @@
 ```
 
 ```
-  wp migrator orders [--before] [--after] [--limit] [--perpage] [--next] [--status] [--ids] [--exclude] [--no-update] [--sorting] [--remove-orphans]
+  wp migrator orders [--before] [--after] [--limit] [--perpage] [--next] [--status] [--ids] [--exclude] [--no-update] [--sorting] [--remove-orphans] [--mode=<live|test>]
 
   OPTIONS
 
@@ -98,4 +99,7 @@
 
   [--remove-orphans]
     Remove orphans order items
+
+  [--mode=<live|test>]
+    Defaults to 'test' where email address is suffixed with '.masked' and phone number is blanked. Please set this flag as 'live' when you wish to do the final migration with unmasked email and phone.
 ```

--- a/migrator.php
+++ b/migrator.php
@@ -1114,7 +1114,7 @@ class Migrator_CLI extends WP_CLI_Command {
 				}
 
 				// Mask phone number in test mode.
-				if ( $mode === 'test' ) {
+				if ( 'test' === $mode ) {
 					if ( isset( $shopify_order->shipping_address->phone ) ) $shopify_order->shipping_address->phone = '9999999999';
 					if ( isset( $shopify_order->billing_address->phone) ) $shopify_order->billing_address->phone = '9999999999';
 				}
@@ -1232,7 +1232,7 @@ class Migrator_CLI extends WP_CLI_Command {
 
 		if ( $shopify_order->email ) {
 			// Mask email in test mode.
-			if ( $mode === 'test' ) {
+			if ( 'test' === $mode ) {
 				$shopify_order->email .= '.masked';
 			}
 			$this->create_or_assign_customer( $order, $shopify_order, $mode );
@@ -1254,27 +1254,6 @@ class Migrator_CLI extends WP_CLI_Command {
 
 		// Refunds
 		$this->process_order_refunds( $order, $shopify_order );
-	}
-
-	/**
-	 * Scramble email address
-	 * Used for test mode order import
-	 *
-	 * @param string $email
-	 * @return string
-	 */
-	private function scrambleEmail( $email ) {
-		$parts = explode( '@', $email );
-		$scrambledEmailId = str_shuffle( $parts[0] );
-
-		// Scramble the domain part
-		$domainParts = explode( '.', $parts[1] );
-		foreach ( $domainParts as &$domainPart ) {
-			$domainPart = str_shuffle( $domainPart );
-		}
-		$scrambledEmailDomain = implode( '.', $domainParts );
-
-		return $scrambledEmailId . '@' . $scrambledEmailDomain;
 	}
 
 	private function create_or_assign_customer( $order, $shopify_order, $mode = 'test' ) {

--- a/migrator.php
+++ b/migrator.php
@@ -1115,8 +1115,13 @@ class Migrator_CLI extends WP_CLI_Command {
 
 				// Mask phone number in test mode.
 				if ( 'test' === $mode ) {
-					if ( isset( $shopify_order->shipping_address->phone ) ) $shopify_order->shipping_address->phone = '9999999999';
-					if ( isset( $shopify_order->billing_address->phone) ) $shopify_order->billing_address->phone = '9999999999';
+					if ( isset( $shopify_order->shipping_address->phone ) ) {
+						$shopify_order->shipping_address->phone = '9999999999';
+					}
+
+					if ( isset( $shopify_order->billing_address->phone) ) {
+						$shopify_order->billing_address->phone = '9999999999';
+					}
 				}
 
 				// Check if the order exists in WooCommerce.

--- a/migrator.php
+++ b/migrator.php
@@ -1247,10 +1247,10 @@ class Migrator_CLI extends WP_CLI_Command {
 	}
 
 	private function create_or_assign_customer( $order, $shopify_order, $mode = 'test' ) {
-		// Mask customer email and phone number in test mode.
+		// Mask customer email and remove phone number in test mode.
 		if ( $mode === 'test' ) {
 			$shopify_order->email = $shopify_order->email . '.masked';
-			$shopify_order->phone = $shopify_order->phone . '.test';
+			$shopify_order->phone = '';
 		}
 
 		// Check if the customer exists in WooCommerce.


### PR DESCRIPTION
Related to #4 

#### Summary 
To avoid accidental send of notification to actual users, the PR seeks to set a default `test` import mode for the `wp migrator orders` import command. Here, we mask the email address, and set the phone number as blank.  The mode can be set to live with a flag `--mode=live` whenever we wish to do the final migration. 

#### Testing instructions
* Create a test site locally with WooCommerce installed
* Install this migrator extension on it, and add credentials of your site on the config.php
* Run `wp migrator orders --limit=10` 
* Check the email address of users showing up on orders as well as `WP admin > users > individual user profiles` .. it should appear with a suffix `.masked`, e.g. `nagesh.pai@youknowwhere.com.masked` , the phone number should appear `9999999999` wherever an order contains phone in the billing / shipping address. Else it will be blank.
* Clear out the users, and orders.
* Now run the command `wp migrator orders --limit=10 --mode=live`
* Check the email addresses and phone number again - it should appear correctly.