### PR TITLE
Disable email notifications during order import

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@
 3. Grab the Shopify Access token by [creating a custom app](https://help.shopify.com/en/manual/apps/app-types/custom-apps). Make sure the required scopes for products and orders migration are selected.
 4. Update domain and access token in the config.php file.
 5. Activate the plugin.
-6. Important note for Order migration - To prevent accidental sending of notifications, there is a `--mode` flag that is set to test by default. This masks the email and phone. Please add `--mode=live` flag whenever you wish to do a final migration with unmasked email and phone. 
+
+## Important Notes
+
+1. For Order migration - To prevent accidental sending of notifications, there is a `--mode` flag that is set to test by default. This masks the email and phone. Please add `--mode=live` flag whenever you wish to do a final migration with unmasked email and phone. 
+2. For order imports, notifications are disabled. These notifications include default emails sent by WooCommerce to users ( 'New Account Created') and site admin ('New Order Received'), for every order has been disabled to prevent spamming. For any reason if you wish to have those notifications sent, please add `--send-notifications` 
 
 ## Commands
 
@@ -102,4 +106,8 @@
 
   [--mode=<live|test>]
     Defaults to 'test' where email address is suffixed with '.masked' and phone number is blanked. Please set this flag as 'live' when you wish to do the final migration with unmasked email and phone.
+
+	[--send-notifications]
+		If this flag is added, the migrator will send out 'New Account created' email notifications to users, for every new user imported; and 'New
+	 order' notification for each order to the site admin email. Beware of potential spamming before adding this flag!
 ```

--- a/migrator.php
+++ b/migrator.php
@@ -12,27 +12,26 @@ if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
 }
 
 // Activation hook to disable wp_email(), to prevent notifications.
+register_activation_hook( __FILE__, 'migrator_activate' );
 function migrator_activate() {
 	add_filter( 'pre_wp_mail', '__return_false' );
-
 }
-register_activation_hook( __FILE__, 'migrator_activate' );
 
+add_action( 'admin_notices', 'migrator_active_notice' );
 function migrator_active_notice() {
 	?>
 	<div class="notice notice-warning is-dismissible">
-		<p><?php _e( 'Migrator plugin is active. Outgoing email notifications are disabled. Please deactivate plugin after migration', 'sample-text-domain' ); ?></p>
+		<p><?php _e( 'Migrator plugin is active. Outgoing email notifications are disabled. Please deactivate plugin after migration', 'migrator' ); ?></p>
 	</div>
 	<?php
 }
-add_action( 'admin_notices', 'migrator_active_notice' );
 
 // Deactivation hook to enable wp_email().
+register_deactivation_hook( __FILE__, 'migrator_deactivate' );
 function migrator_deactivate() {
 	remove_filter( 'pre_wp_mail', '__return_false' );
 	remove_action( 'admin_notices', 'migrator_active_notice' );
 }
-register_deactivation_hook( __FILE__, 'migrator_deactivate' );
 
 // Only include the config.php file if exists
 if ( file_exists( __DIR__ . '/config.php' ) ) {

--- a/migrator.php
+++ b/migrator.php
@@ -11,6 +11,29 @@ if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
 	return;
 }
 
+// Activation hook to disable wp_email(), to prevent notifications.
+function migrator_activate() {
+	add_filter( 'pre_wp_mail', '__return_false' );
+
+}
+register_activation_hook( __FILE__, 'migrator_activate' );
+
+function migrator_active_notice() {
+	?>
+	<div class="notice notice-warning is-dismissible">
+		<p><?php _e( 'Migrator plugin is active. Outgoing email notifications are disabled. Please deactivate plugin after migration', 'sample-text-domain' ); ?></p>
+	</div>
+	<?php
+}
+add_action( 'admin_notices', 'migrator_active_notice' );
+
+// Deactivation hook to enable wp_email().
+function migrator_deactivate() {
+	remove_filter( 'pre_wp_mail', '__return_false' );
+	remove_action( 'admin_notices', 'migrator_active_notice' );
+}
+register_deactivation_hook( __FILE__, 'migrator_deactivate' );
+
 // Only include the config.php file if exists
 if ( file_exists( __DIR__ . '/config.php' ) ) {
 	require_once __DIR__ . '/config.php';

--- a/migrator.php
+++ b/migrator.php
@@ -17,7 +17,6 @@ function migrator_activate() {
 	add_filter( 'pre_wp_mail', '__return_false' );
 }
 
-add_action( 'admin_notices', 'migrator_active_notice' );
 function migrator_active_notice() {
 	?>
 	<div class="notice notice-warning is-dismissible">
@@ -25,6 +24,7 @@ function migrator_active_notice() {
 	</div>
 	<?php
 }
+add_action( 'admin_notices', 'migrator_active_notice' );
 
 // Deactivation hook to enable wp_email().
 register_deactivation_hook( __FILE__, 'migrator_deactivate' );


### PR DESCRIPTION
Fixes #4 

#### Summary 
The PR disables all WP email notifications, including Woo, while importing new orders and creating new customers. The PR uses the `pre_wp_mail` hook  

#### Testing instructions
* Best tested on a local WP site  and with our test shop credentials. LocalWP has a MailHog app that captures all emails being sent out and received successfully. 
* Checkout to trunk ( without the changes ) and do a test `wp migrator orders` .  Within localWP browse to `Tools > MailHog > Open MailHog`

![image](https://github.com/woocommerce/migrator-cli/assets/4162931/4c533ebc-66e9-4e24-b7de-0d4b9463247b)

* You will see a trail of emails sent by the import operation
* Empty the MailHog mailbox
* Now check-out to this branch, and then repeat the steps
* You should see an empty MailHog Mailbox. 

#### Additional testing for `--send-notifications` flag added in 4d6fea0 ( Props @leonardola )

* Empty existing test content ( users, orders, mail logs etc )
* Run `wp migrator orders --send-notifications` 
* Check MailHog logs, where you should see attempts to email `New orders` email to admin, and `New Account created` mails to masked emails of users. 
* Repeat the test with `wp migrator orders --send-notifications --mode=live` 
* You will see send attempts to actual email address in MailHog